### PR TITLE
Fix typo in gas limit comment

### DIFF
--- a/hardhat-scripts/utils/overrides.ts
+++ b/hardhat-scripts/utils/overrides.ts
@@ -55,7 +55,7 @@ export const getOverrides = async (
   if (gasPrice == undefined || gasPrice == null)
     gasPrice = (await getGasPrice(chainSlug, provider)).toNumber();
   if (type == undefined) type = defaultType;
-  // if gas limit is undefined, ethers will calcuate it automatically. If want to override,
+  // if gas limit is undefined, ethers will calculate it automatically. If want to override,
   // add in the overrides object. Dont set a default value
   return { gasLimit, gasPrice, type };
 };


### PR DESCRIPTION


**Description:**
Corrects a spelling error in the comment where "calcuate" was misspelled as "calculate". This is a minor documentation fix that improves code readability.

Changes made:
- Fixed typo in comment on line 58 of `hardhat-scripts/utils/overrides.ts`
- No functional changes, only comment correction
