### PR TITLE
Change switchboard and socket address types to bytes32

### DIFF
--- a/contracts/evmx/Forwarder.sol
+++ b/contracts/evmx/Forwarder.sol
@@ -8,6 +8,7 @@ import "./interfaces/IPromise.sol";
 import "./interfaces/IForwarder.sol";
 import {AddressResolverUtil} from "./AddressResolverUtil.sol";
 import {AsyncModifierNotUsed, NoAsyncPromiseFound, PromiseCallerMismatch, RequestCountMismatch, DeliveryHelperNotSet} from "../utils/common/Errors.sol";
+import { toBytes32Format } from "../utils/common/Converters.sol";
 import "solady/utils/Initializable.sol";
 
 /// @title Forwarder Storage
@@ -20,7 +21,7 @@ abstract contract ForwarderStorage is IForwarder {
     /// @notice chain slug on which the contract is deployed
     uint32 public chainSlug;
     /// @notice on-chain address associated with this forwarder
-    address public onChainAddress;
+    bytes32 public onChainAddress;
 
     // slot 51
     /// @notice caches the latest async promise address for the last call
@@ -51,7 +52,7 @@ contract Forwarder is ForwarderStorage, Initializable, AddressResolverUtil {
     /// @param addressResolver_ address resolver contract
     function initialize(
         uint32 chainSlug_,
-        address onChainAddress_,
+        bytes32 onChainAddress_,
         address addressResolver_
     ) public initializer {
         chainSlug = chainSlug_;
@@ -79,7 +80,7 @@ contract Forwarder is ForwarderStorage, Initializable, AddressResolverUtil {
 
     /// @notice Returns the on-chain address associated with this forwarder.
     /// @return The on-chain address.
-    function getOnChainAddress() external view returns (address) {
+    function getOnChainAddress() external view returns (bytes32) {
         return onChainAddress;
     }
 
@@ -119,7 +120,7 @@ contract Forwarder is ForwarderStorage, Initializable, AddressResolverUtil {
         ) = IAppGateway(msg.sender).getOverrideParams();
 
         // get the switchboard address from the watcher precompile config
-        address switchboard = watcherPrecompileConfig().switchboards(chainSlug, sbType);
+        bytes32 switchboard = watcherPrecompileConfig().switchboards(chainSlug, sbType);
 
         // Queue the call in the middleware.
         deliveryHelper__().queue(

--- a/contracts/evmx/Forwarder.sol
+++ b/contracts/evmx/Forwarder.sol
@@ -8,7 +8,6 @@ import "./interfaces/IPromise.sol";
 import "./interfaces/IForwarder.sol";
 import {AddressResolverUtil} from "./AddressResolverUtil.sol";
 import {AsyncModifierNotUsed, NoAsyncPromiseFound, PromiseCallerMismatch, RequestCountMismatch, DeliveryHelperNotSet} from "../utils/common/Errors.sol";
-import { toBytes32Format } from "../utils/common/Converters.sol";
 import "solady/utils/Initializable.sol";
 
 /// @title Forwarder Storage

--- a/contracts/evmx/base/AppGatewayBase.sol
+++ b/contracts/evmx/base/AppGatewayBase.sol
@@ -9,6 +9,7 @@ import "../interfaces/IPromise.sol";
 
 import {InvalidPromise, FeesNotSet, AsyncModifierNotUsed} from "../../utils/common/Errors.sol";
 import {FAST} from "../../utils/common/Constants.sol";
+import { toBytes32Format } from "../../utils/common/Converters.sol";
 
 /// @title AppGatewayBase
 /// @notice Abstract contract for the app gateway
@@ -122,7 +123,7 @@ abstract contract AppGatewayBase is AddressResolverUtil, IAppGateway {
     /// @param isValid Boolean flag indicating whether the contract is authorized (true) or not (false)
     /// @dev This function retrieves the onchain address using the contractId and chainSlug, then calls the watcher precompile to update the plug's validity status
     function _setValidPlug(uint32 chainSlug_, bytes32 contractId, bool isValid) internal {
-        address onchainAddress = getOnChainAddress(contractId, chainSlug_);
+        bytes32 onchainAddress = getOnChainAddress(contractId, chainSlug_);
         watcherPrecompileConfig().setIsValidPlug(chainSlug_, onchainAddress, isValid);
     }
 
@@ -154,6 +155,8 @@ abstract contract AppGatewayBase is AddressResolverUtil, IAppGateway {
         isValidPromise[asyncPromise] = true;
         onCompleteData = abi.encode(chainSlug_, true);
 
+        bytes32 switchboardAddress = watcherPrecompileConfig().switchboards(chainSlug_, sbType);
+
         QueuePayloadParams memory queuePayloadParams = QueuePayloadParams({
             chainSlug: chainSlug_,
             callType: CallType.DEPLOY,
@@ -161,8 +164,8 @@ abstract contract AppGatewayBase is AddressResolverUtil, IAppGateway {
             isPlug: isPlug_,
             writeFinality: overrideParams.writeFinality,
             asyncPromise: asyncPromise,
-            switchboard: watcherPrecompileConfig().switchboards(chainSlug_, sbType),
-            target: address(0),
+            switchboard: switchboardAddress,
+            target: toBytes32Format(address(0)),
             appGateway: address(this),
             gasLimit: overrideParams.gasLimit,
             value: overrideParams.value,
@@ -190,7 +193,7 @@ abstract contract AppGatewayBase is AddressResolverUtil, IAppGateway {
     /// @notice Gets the socket address
     /// @param chainSlug_ The chain slug
     /// @return socketAddress_ The socket address
-    function getSocketAddress(uint32 chainSlug_) public view returns (address) {
+    function getSocketAddress(uint32 chainSlug_) public view returns (bytes32) {
         return watcherPrecompileConfig().sockets(chainSlug_);
     }
 
@@ -201,9 +204,9 @@ abstract contract AppGatewayBase is AddressResolverUtil, IAppGateway {
     function getOnChainAddress(
         bytes32 contractId_,
         uint32 chainSlug_
-    ) public view returns (address onChainAddress) {
+    ) public view returns (bytes32 onChainAddress) {
         if (forwarderAddresses[contractId_][chainSlug_] == address(0)) {
-            return address(0);
+            return bytes32(0x0);
         }
 
         onChainAddress = IForwarder(forwarderAddresses[contractId_][chainSlug_])

--- a/contracts/evmx/interfaces/IAppGateway.sol
+++ b/contracts/evmx/interfaces/IAppGateway.sol
@@ -44,7 +44,7 @@ interface IAppGateway {
     function getOnChainAddress(
         bytes32 contractId_,
         uint32 chainSlug_
-    ) external view returns (address onChainAddress);
+    ) external view returns (bytes32 onChainAddress);
 
     /// @notice get the forwarder address of a contract
     /// @param contractId_ The contract id

--- a/contracts/evmx/interfaces/IForwarder.sol
+++ b/contracts/evmx/interfaces/IForwarder.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.21;
 interface IForwarder {
     /// @notice Returns the on-chain address of the contract being referenced
     /// @return The on-chain address
-    function getOnChainAddress() external view returns (address);
+    function getOnChainAddress() external view returns (bytes32);
 
     /// @notice Returns the chain slug of the on chain contract
     /// @return The chain slug

--- a/contracts/evmx/interfaces/IWatcherPrecompileConfig.sol
+++ b/contracts/evmx/interfaces/IWatcherPrecompileConfig.sol
@@ -11,10 +11,10 @@ interface IWatcherPrecompileConfig {
     function evmxSlug() external view returns (uint32);
 
     /// @notice Maps chain slug to their associated switchboard
-    function switchboards(uint32 chainSlug, bytes32 sbType) external view returns (address);
+    function switchboards(uint32 chainSlug, bytes32 sbType) external view returns (bytes32);
 
     /// @notice Maps chain slug to their associated socket
-    function sockets(uint32 chainSlug) external view returns (address);
+    function sockets(uint32 chainSlug) external view returns (bytes32);
 
     /// @notice Maps chain slug to their associated contract factory plug
     function contractFactoryPlug(uint32 chainSlug) external view returns (address);
@@ -29,28 +29,28 @@ interface IWatcherPrecompileConfig {
     function isValidPlug(
         address appGateway,
         uint32 chainSlug,
-        address plug
+        bytes32 plug
     ) external view returns (bool);
 
     /// @notice Sets the switchboard for a network
-    function setSwitchboard(uint32 chainSlug_, bytes32 sbType_, address switchboard_) external;
+    function setSwitchboard(uint32 chainSlug_, bytes32 sbType_, bytes32 switchboard_) external;
 
     /// @notice Sets valid plugs for each chain slug
     /// @dev This function is used to verify if a plug deployed on a chain slug is valid connection to the app gateway
-    function setIsValidPlug(uint32 chainSlug_, address plug_, bool isValid_) external;
+    function setIsValidPlug(uint32 chainSlug_, bytes32 plug_, bool isValid_) external;
 
     /// @notice Retrieves the configuration for a specific plug on a network
     function getPlugConfigs(
         uint32 chainSlug_,
-        address plug_
-    ) external view returns (bytes32, address);
+        bytes32 plug_
+    ) external view returns (bytes32, bytes32);
 
     /// @notice Verifies connections between components
     function verifyConnections(
         uint32 chainSlug_,
-        address target_,
+        bytes32 target_,
         address appGateway_,
-        address switchboard_,
+        bytes32 switchboard_,
         address middleware_
     ) external view;
 

--- a/contracts/evmx/interfaces/IWatcherPrecompileConfig.sol
+++ b/contracts/evmx/interfaces/IWatcherPrecompileConfig.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.21;
 
-import {AppGatewayConfig, PlugConfig} from "../../utils/common/Structs.sol";
+import {AppGatewayConfig, PlugConfigGeneric} from "../../utils/common/Structs.sol";
 
 /// @title IWatcherPrecompileConfig
 /// @notice Interface for the Watcher Precompile system that handles payload verification and execution
@@ -17,10 +17,10 @@ interface IWatcherPrecompileConfig {
     function sockets(uint32 chainSlug) external view returns (bytes32);
 
     /// @notice Maps chain slug to their associated contract factory plug
-    function contractFactoryPlug(uint32 chainSlug) external view returns (address);
+    function contractFactoryPlug(uint32 chainSlug) external view returns (bytes32);
 
     /// @notice Maps chain slug to their associated fees plug
-    function feesPlug(uint32 chainSlug) external view returns (address);
+    function feesPlug(uint32 chainSlug) external view returns (bytes32);
 
     /// @notice Maps nonce to whether it has been used
     function isNonceUsed(uint256 nonce) external view returns (bool);

--- a/contracts/evmx/payload-delivery/FeesManager.sol
+++ b/contracts/evmx/payload-delivery/FeesManager.sol
@@ -9,7 +9,6 @@ import "../interfaces/IFeesManager.sol";
 import {AddressResolverUtil} from "../AddressResolverUtil.sol";
 import {NotAuctionManager, InvalidWatcherSignature, NonceUsed} from "../../utils/common/Errors.sol";
 import {Bid, CallType, Parallel, WriteFinality, QueuePayloadParams, IsPlug, PayloadSubmitParams, RequestMetadata, UserCredits} from "../../utils/common/Structs.sol";
-import { toBytes32Format } from "../../utils/common/Converters.sol";
 
 abstract contract FeesManagerStorage is IFeesManager {
     // slots [0-49] reserved for gap
@@ -430,7 +429,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
             writeFinality: WriteFinality.LOW,
             asyncPromise: address(0),
             switchboard: _getSwitchboard(chainSlug_),
-            target: toBytes32Format(_getFeesPlugAddress(chainSlug_)),
+            target: _getFeesPlugAddress(chainSlug_),
             appGateway: address(this),
             gasLimit: 10000000,
             value: 0,
@@ -463,7 +462,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
                 writeFinality: WriteFinality.LOW,
                 asyncPromise: address(0),
                 switchboard: _getSwitchboard(chainSlug_),
-                target: toBytes32Format(_getFeesPlugAddress(chainSlug_)),
+                target: _getFeesPlugAddress(chainSlug_),
                 appGateway: address(this),
                 gasLimit: 10000000,
                 value: 0,
@@ -484,7 +483,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
         deliveryHelper__().queue(queuePayloadParams);
     }
 
-    function _getFeesPlugAddress(uint32 chainSlug_) internal view returns (address) {
+    function _getFeesPlugAddress(uint32 chainSlug_) internal view returns (bytes32) {
         return watcherPrecompileConfig().feesPlug(chainSlug_);
     }
 

--- a/contracts/evmx/payload-delivery/FeesManager.sol
+++ b/contracts/evmx/payload-delivery/FeesManager.sol
@@ -9,6 +9,7 @@ import "../interfaces/IFeesManager.sol";
 import {AddressResolverUtil} from "../AddressResolverUtil.sol";
 import {NotAuctionManager, InvalidWatcherSignature, NonceUsed} from "../../utils/common/Errors.sol";
 import {Bid, CallType, Parallel, WriteFinality, QueuePayloadParams, IsPlug, PayloadSubmitParams, RequestMetadata, UserCredits} from "../../utils/common/Structs.sol";
+import { toBytes32Format } from "../../utils/common/Converters.sol";
 
 abstract contract FeesManagerStorage is IFeesManager {
     // slots [0-49] reserved for gap
@@ -429,7 +430,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
             writeFinality: WriteFinality.LOW,
             asyncPromise: address(0),
             switchboard: _getSwitchboard(chainSlug_),
-            target: _getFeesPlugAddress(chainSlug_),
+            target: toBytes32Format(_getFeesPlugAddress(chainSlug_)),
             appGateway: address(this),
             gasLimit: 10000000,
             value: 0,
@@ -445,7 +446,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
         return transmitterCredits > watcherFees ? transmitterCredits - watcherFees : 0;
     }
 
-    function _getSwitchboard(uint32 chainSlug_) internal view returns (address) {
+    function _getSwitchboard(uint32 chainSlug_) internal view returns (bytes32) {
         return watcherPrecompile__().watcherPrecompileConfig__().switchboards(chainSlug_, sbType);
     }
 
@@ -462,7 +463,7 @@ contract FeesManager is FeesManagerStorage, Initializable, Ownable, AddressResol
                 writeFinality: WriteFinality.LOW,
                 asyncPromise: address(0),
                 switchboard: _getSwitchboard(chainSlug_),
-                target: _getFeesPlugAddress(chainSlug_),
+                target: toBytes32Format(_getFeesPlugAddress(chainSlug_)),
                 appGateway: address(this),
                 gasLimit: 10000000,
                 value: 0,

--- a/contracts/evmx/payload-delivery/app-gateway/DeliveryUtils.sol
+++ b/contracts/evmx/payload-delivery/app-gateway/DeliveryUtils.sol
@@ -63,7 +63,7 @@ abstract contract DeliveryUtils is
     /// @notice Gets the payload delivery plug address
     /// @param chainSlug_ The chain identifier
     /// @return address The address of the payload delivery plug
-    function getDeliveryHelperPlugAddress(uint32 chainSlug_) public view returns (address) {
+    function getDeliveryHelperPlugAddress(uint32 chainSlug_) public view returns (bytes32) {
         return watcherPrecompileConfig().contractFactoryPlug(chainSlug_);
     }
 

--- a/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
+++ b/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
@@ -194,7 +194,7 @@ abstract contract RequestQueue is DeliveryUtils {
         );
 
         // getting app gateway for deployer as the plug is connected to the app gateway
-        target = toBytes32Format(getDeliveryHelperPlugAddress(queuePayloadParams_.chainSlug));
+        target = getDeliveryHelperPlugAddress(queuePayloadParams_.chainSlug);
     }
 
     /// @notice Creates the payload details for a given call parameters

--- a/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
+++ b/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.21;
 
 import "./DeliveryUtils.sol";
-import { toBytes32Format } from "../../../utils/common/Converters.sol";
 
 /// @notice Abstract contract for managing asynchronous payloads
 abstract contract RequestQueue is DeliveryUtils {

--- a/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
+++ b/contracts/evmx/payload-delivery/app-gateway/RequestQueue.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.21;
 
 import "./DeliveryUtils.sol";
+import { toBytes32Format } from "../../../utils/common/Converters.sol";
 
 /// @notice Abstract contract for managing asynchronous payloads
 abstract contract RequestQueue is DeliveryUtils {
@@ -176,7 +177,7 @@ abstract contract RequestQueue is DeliveryUtils {
 
     function _createDeployPayloadDetails(
         QueuePayloadParams memory queuePayloadParams_
-    ) internal returns (bytes memory payload, address target) {
+    ) internal returns (bytes memory payload, bytes32 target) {
         bytes32 salt = keccak256(
             abi.encode(queuePayloadParams_.appGateway, queuePayloadParams_.chainSlug, saltCounter++)
         );
@@ -193,7 +194,7 @@ abstract contract RequestQueue is DeliveryUtils {
         );
 
         // getting app gateway for deployer as the plug is connected to the app gateway
-        target = getDeliveryHelperPlugAddress(queuePayloadParams_.chainSlug);
+        target = toBytes32Format(getDeliveryHelperPlugAddress(queuePayloadParams_.chainSlug));
     }
 
     /// @notice Creates the payload details for a given call parameters
@@ -204,7 +205,7 @@ abstract contract RequestQueue is DeliveryUtils {
         QueuePayloadParams memory queuePayloadParams_
     ) internal returns (PayloadSubmitParams memory) {
         bytes memory payload = queuePayloadParams_.payload;
-        address target = queuePayloadParams_.target;
+        bytes32 target = queuePayloadParams_.target;
         if (queuePayloadParams_.callType == CallType.DEPLOY) {
             (payload, target) = _createDeployPayloadDetails(queuePayloadParams_);
         }

--- a/contracts/evmx/watcherPrecompile/WatcherPrecompileConfig.sol
+++ b/contracts/evmx/watcherPrecompile/WatcherPrecompileConfig.sol
@@ -8,7 +8,6 @@ import "../interfaces/IWatcherPrecompileConfig.sol";
 import {AddressResolverUtil} from "../AddressResolverUtil.sol";
 import {InvalidWatcherSignature, NonceUsed} from "../../utils/common/Errors.sol";
 import {toBytes32Format} from "../../utils/common/Converters.sol";
-import "./core/WatcherIdUtils.sol";
 
 /// @title WatcherPrecompileConfig
 /// @notice Configuration contract for the Watcher Precompile system
@@ -209,7 +208,7 @@ contract WatcherPrecompileConfig is
         ) return;
 
         (bytes32 appGatewayId, bytes32 switchboard) = getPlugConfigs(chainSlug_, target_);
-        if (appGatewayId != WatcherIdUtils.encodeAppGatewayId(appGateway_)) revert InvalidGateway();
+        if (appGatewayId != toBytes32Format(appGateway_)) revert InvalidGateway();
         if (switchboard != switchboard_) revert InvalidSwitchboard();
     }
 

--- a/contracts/evmx/watcherPrecompile/WatcherPrecompileConfig.sol
+++ b/contracts/evmx/watcherPrecompile/WatcherPrecompileConfig.sol
@@ -30,8 +30,8 @@ contract WatcherPrecompileConfig is
 
     // slot 102: _plugConfigs
     /// @notice Maps network and plug to their configuration
-    /// @dev chainSlug => plug => PlugConfig
-    mapping(uint32 => mapping(bytes32 => PlugConfig)) internal _plugConfigs;
+    /// @dev chainSlug => plug => PlugConfigGeneric
+    mapping(uint32 => mapping(bytes32 => PlugConfigGeneric)) internal _plugConfigs;
 
     // slot 103: switchboards
     /// @notice Maps chain slug to their associated switchboard
@@ -46,12 +46,12 @@ contract WatcherPrecompileConfig is
     // slot 105: contractFactoryPlug
     /// @notice Maps chain slug to their associated contract factory plug
     /// @dev chainSlug => contract factory plug address
-    mapping(uint32 => address) public contractFactoryPlug;
+    mapping(uint32 => bytes32) public contractFactoryPlug;
 
     // slot 106: feesPlug
     /// @notice Maps chain slug to their associated fees plug
     /// @dev chainSlug => fees plug address
-    mapping(uint32 => address) public feesPlug;
+    mapping(uint32 => bytes32) public feesPlug;
 
     // slot 107: isNonceUsed
     /// @notice Maps nonce to whether it has been used
@@ -82,8 +82,8 @@ contract WatcherPrecompileConfig is
     event OnChainContractSet(
         uint32 chainSlug,
         bytes32 socket,
-        address contractFactoryPlug,
-        address feesPlug
+        bytes32 contractFactoryPlug,
+        bytes32 feesPlug
     );
 
     /// @notice Emitted when a valid plug is set for an app gateway
@@ -125,7 +125,7 @@ contract WatcherPrecompileConfig is
 
         for (uint256 i = 0; i < configs_.length; i++) {
             // Store the plug configuration for this network and plug
-            _plugConfigs[configs_[i].chainSlug][configs_[i].plug] = PlugConfig({
+            _plugConfigs[configs_[i].chainSlug][configs_[i].plug] = PlugConfigGeneric({
                 appGatewayId: configs_[i].appGatewayId,
                 switchboard: configs_[i].switchboard
             });
@@ -139,8 +139,8 @@ contract WatcherPrecompileConfig is
     function setOnChainContracts(
         uint32 chainSlug_,
         bytes32 socket_,
-        address contractFactoryPlug_,
-        address feesPlug_
+        bytes32 contractFactoryPlug_,
+        bytes32 feesPlug_
     ) external onlyOwner {
         sockets[chainSlug_] = socket_;
         contractFactoryPlug[chainSlug_] = contractFactoryPlug_;
@@ -205,7 +205,7 @@ contract WatcherPrecompileConfig is
         // if target is contractFactoryPlug, return
         // as connection is with middleware delivery helper and not app gateway
         if (
-            middleware_ == address(deliveryHelper__()) && target_ == toBytes32Format(contractFactoryPlug[chainSlug_])
+            middleware_ == address(deliveryHelper__()) && target_ == contractFactoryPlug[chainSlug_]
         ) return;
 
         (bytes32 appGatewayId, bytes32 switchboard) = getPlugConfigs(chainSlug_, target_);

--- a/contracts/evmx/watcherPrecompile/core/RequestHandler.sol
+++ b/contracts/evmx/watcherPrecompile/core/RequestHandler.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.21;
 
 import "./WatcherPrecompileCore.sol";
+import {WatcherIdUtils} from "./WatcherIdUtils.sol";
 
 /// @title RequestHandler
 /// @notice Contract that handles request submission and processing

--- a/contracts/evmx/watcherPrecompile/core/RequestHandler.sol
+++ b/contracts/evmx/watcherPrecompile/core/RequestHandler.sol
@@ -21,7 +21,7 @@ abstract contract RequestHandler is WatcherPrecompileCore {
     function submitRequest(
         PayloadSubmitParams[] memory payloadSubmitParams_
     ) public returns (uint40 requestCount) {
-        address appGateway = _checkAppGateways(payloadSubmitParams_);
+        _checkAppGateways(payloadSubmitParams_);
 
         requestCount = nextRequestCount++;
         uint40 batchCount = nextBatchCount;

--- a/contracts/evmx/watcherPrecompile/core/WatcherIdUtils.sol
+++ b/contracts/evmx/watcherPrecompile/core/WatcherIdUtils.sol
@@ -2,14 +2,6 @@
 pragma solidity ^0.8.22;
 
 library WatcherIdUtils {
-    function encodeAppGatewayId(address appGateway_) internal pure returns (bytes32) {
-        return bytes32(uint256(uint160(appGateway_)));
-    }
-
-    function decodeAppGatewayId(bytes32 appGatewayId_) internal pure returns (address) {
-        return address(uint160(uint256(appGatewayId_)));
-    }
-
     /// @notice Creates a payload ID from the given parameters
     /// @param requestCount_ The request count
     /// @param batchCount_ The batch count

--- a/contracts/evmx/watcherPrecompile/core/WatcherIdUtils.sol
+++ b/contracts/evmx/watcherPrecompile/core/WatcherIdUtils.sol
@@ -21,7 +21,7 @@ library WatcherIdUtils {
         uint40 requestCount_,
         uint40 batchCount_,
         uint40 payloadCount_,
-        address switchboard_,
+        bytes32 switchboard_,
         uint32 chainSlug_
     ) internal pure returns (bytes32) {
         return

--- a/contracts/evmx/watcherPrecompile/core/WatcherPrecompile.sol
+++ b/contracts/evmx/watcherPrecompile/core/WatcherPrecompile.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.21;
 
 import "./RequestHandler.sol";
 import {LibCall} from "solady/utils/LibCall.sol";
+import {fromBytes32Format} from "../../../utils/common/Converters.sol";
 
 /// @title WatcherPrecompile
 /// @notice Contract that handles request submission, iteration and execution
@@ -254,7 +255,7 @@ contract WatcherPrecompile is RequestHandler {
         for (uint256 i = 0; i < params_.length; i++) {
             if (appGatewayCalled[params_[i].triggerId]) revert AppGatewayAlreadyCalled();
 
-            address appGateway = WatcherIdUtils.decodeAppGatewayId(params_[i].appGatewayId);
+            address appGateway = fromBytes32Format(params_[i].appGatewayId);
             if (
                 !watcherPrecompileConfig__.isValidPlug(
                     appGateway,

--- a/contracts/evmx/watcherPrecompile/core/WatcherPrecompileCore.sol
+++ b/contracts/evmx/watcherPrecompile/core/WatcherPrecompileCore.sol
@@ -7,7 +7,7 @@ import {Ownable} from "solady/auth/Ownable.sol";
 import "solady/utils/Initializable.sol";
 import {AddressResolverUtil} from "../../AddressResolverUtil.sol";
 import {IFeesManager} from "../../interfaces/IFeesManager.sol";
-import "./WatcherIdUtils.sol";
+import {toBytes32Format} from "../../../utils/common/Converters.sol";
 import "./WatcherPrecompileStorage.sol";
 
 /// @title WatcherPrecompileCore
@@ -92,7 +92,7 @@ abstract contract WatcherPrecompileCore is
             params_.value,
             params_.payload,
             params_.target,
-            WatcherIdUtils.encodeAppGatewayId(params_.appGateway),
+            toBytes32Format(params_.appGateway),
             prevDigestsHash
         );
 
@@ -163,7 +163,7 @@ abstract contract WatcherPrecompileCore is
                 p.value,
                 p.payload,
                 p.target,
-                WatcherIdUtils.encodeAppGatewayId(p.appGateway),
+                toBytes32Format(p.appGateway),
                 p.prevDigestsHash
             );
             prevDigestsHash = keccak256(abi.encodePacked(prevDigestsHash, getDigest(digestParams)));

--- a/contracts/evmx/watcherPrecompile/core/WatcherPrecompileStorage.sol
+++ b/contracts/evmx/watcherPrecompile/core/WatcherPrecompileStorage.sol
@@ -8,7 +8,7 @@ import {IPromise} from "../../interfaces/IPromise.sol";
 import {IMiddleware} from "../../interfaces/IMiddleware.sol";
 import {QUERY, FINALIZE, SCHEDULE, MAX_COPY_BYTES} from "../../../utils/common/Constants.sol";
 import {InvalidCallerTriggered, TimeoutDelayTooLarge, TimeoutAlreadyResolved, InvalidInboxCaller, ResolvingTimeoutTooEarly, CallFailed, AppGatewayAlreadyCalled, InvalidWatcherSignature, NonceUsed, RequestAlreadyExecuted} from "../../../utils/common/Errors.sol";
-import {ResolvedPromises, AppGatewayConfig, LimitParams, WriteFinality, UpdateLimitParams, PlugConfig, DigestParams, TimeoutRequest, QueuePayloadParams, PayloadParams, RequestParams, RequestMetadata} from "../../../utils/common/Structs.sol";
+import {ResolvedPromises, AppGatewayConfig, LimitParams, WriteFinality, UpdateLimitParams, PlugConfigGeneric, DigestParams, TimeoutRequest, QueuePayloadParams, PayloadParams, RequestParams, RequestMetadata} from "../../../utils/common/Structs.sol";
 
 /// @title WatcherPrecompileStorage
 /// @notice Storage contract for the WatcherPrecompile system

--- a/contracts/protocol/Socket.sol
+++ b/contracts/protocol/Socket.sol
@@ -84,7 +84,7 @@ contract Socket is SocketUtils {
         if (msg.value < executeParams_.value + transmissionParams_.socketFees)
             revert InsufficientMsgValue();
 
-        bytes32 payloadId = _createPayloadId(plugConfig.switchboard, executeParams_);
+        bytes32 payloadId = _createPayloadId(fromBytes32Format(plugConfig.switchboard), executeParams_);
 
         // validate the execution status
         _validateExecutionStatus(payloadId);
@@ -107,7 +107,7 @@ contract Socket is SocketUtils {
         payloadIdToDigest[payloadId] = digest;
 
         // verify the digest
-        _verify(digest, payloadId, plugConfig.switchboard);
+        _verify(digest, payloadId, fromBytes32Format(plugConfig.switchboard));
 
         return _execute(payloadId, executeParams_, transmissionParams_);
     }
@@ -193,7 +193,7 @@ contract Socket is SocketUtils {
         emit AppGatewayCallRequested(
             triggerId,
             plugConfig.appGatewayId,
-            plugConfig.switchboard,
+            fromBytes32Format(plugConfig.switchboard),
             plug_,
             // gets the overrides from the plug
             IPlug(plug_).overrides(),

--- a/contracts/protocol/SocketConfig.sol
+++ b/contracts/protocol/SocketConfig.sol
@@ -10,7 +10,7 @@ import {GOVERNANCE_ROLE, RESCUE_ROLE, SWITCHBOARD_DISABLER_ROLE} from "../utils/
 import {CallType, PlugConfig, SwitchboardStatus, ExecutionStatus} from "../utils/common/Structs.sol";
 import {PlugNotFound, InvalidAppGateway, InvalidTransmitter} from "../utils/common/Errors.sol";
 import {MAX_COPY_BYTES} from "../utils/common/Constants.sol";
-
+import {toBytes32Format, fromBytes32Format} from "../utils/common/Converters.sol";
 /**
  * @title SocketConfig
  * @notice An abstract contract for configuring socket connections for plugs,
@@ -25,6 +25,8 @@ abstract contract SocketConfig is ISocket, AccessControl {
     mapping(address => SwitchboardStatus) public isValidSwitchboard;
 
     // @notice mapping of plug address to its config
+    // TODO:GW: remove comment after review: PlugConfig is shared with WatcherPrecompile which handles solana so switchboard needs to be bytes32
+    //       another option is the have a separate struct PlugConfigEvm for EVM only
     mapping(address => PlugConfig) internal _plugConfigs;
 
     // @notice max copy bytes for socket
@@ -86,7 +88,8 @@ abstract contract SocketConfig is ISocket, AccessControl {
         PlugConfig storage _plugConfig = _plugConfigs[msg.sender];
 
         _plugConfig.appGatewayId = appGatewayId_;
-        _plugConfig.switchboard = switchboard_;
+        // This is used by watcher precompile which need to also handle bytes32 format for Solana
+        _plugConfig.switchboard = toBytes32Format(switchboard_);
 
         emit PlugConnected(msg.sender, appGatewayId_, switchboard_);
     }
@@ -108,6 +111,6 @@ abstract contract SocketConfig is ISocket, AccessControl {
         address plugAddress_
     ) external view returns (bytes32 appGatewayId, address switchboard) {
         PlugConfig memory _plugConfig = _plugConfigs[plugAddress_];
-        return (_plugConfig.appGatewayId, _plugConfig.switchboard);
+        return (_plugConfig.appGatewayId, fromBytes32Format(_plugConfig.switchboard));
     }
 }

--- a/contracts/protocol/SocketConfig.sol
+++ b/contracts/protocol/SocketConfig.sol
@@ -86,7 +86,6 @@ abstract contract SocketConfig is ISocket, AccessControl {
         PlugConfigEvm storage _plugConfig = _plugConfigs[msg.sender];
 
         _plugConfig.appGatewayId = appGatewayId_;
-        // This is used by watcher precompile which need to also handle bytes32 format for Solana
         _plugConfig.switchboard = switchboard_;
 
         emit PlugConnected(msg.sender, appGatewayId_, switchboard_);

--- a/contracts/utils/common/Converters.sol
+++ b/contracts/utils/common/Converters.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.21;
+
+error NotAnEvmAddress(bytes32 bytes32FormatAddress);
+
+function toBytes32Format(address addr) pure returns (bytes32) {
+    return bytes32(uint256(uint160(addr)));
+}
+
+function fromBytes32Format(bytes32 bytes32FormatAddress) pure returns (address) {
+    if (uint256(bytes32FormatAddress) >> 160 != 0) {
+        revert NotAnEvmAddress(bytes32FormatAddress);
+    }
+    return address(uint160(uint256(bytes32FormatAddress)));
+}

--- a/contracts/utils/common/Structs.sol
+++ b/contracts/utils/common/Structs.sol
@@ -88,10 +88,17 @@ struct AppGatewayConfig {
     uint32 chainSlug;
 }
 // Plug config:
-struct PlugConfig {
+struct PlugConfigGeneric {
     bytes32 appGatewayId;
     bytes32 switchboard;
 }
+
+// Plug config:
+struct PlugConfigEvm {
+    bytes32 appGatewayId;
+    address switchboard;
+}
+
 //trigger:
 struct TriggerParams {
     bytes32 triggerId;
@@ -244,7 +251,6 @@ struct RequestMetadata {
     bytes onCompleteData;
 }
 
-// TODO:GW: remove comment after review: ExecuteParams is for EVM calls - should we name it ExecuteParamsEvm?
 struct ExecuteParams {
     CallType callType;
     uint40 requestCount;

--- a/contracts/utils/common/Structs.sol
+++ b/contracts/utils/common/Structs.sol
@@ -82,20 +82,20 @@ struct UpdateLimitParams {
 }
 
 struct AppGatewayConfig {
-    address plug;
+    bytes32 plug;
     bytes32 appGatewayId;
-    address switchboard;
+    bytes32 switchboard;
     uint32 chainSlug;
 }
 // Plug config:
 struct PlugConfig {
     bytes32 appGatewayId;
-    address switchboard;
+    bytes32 switchboard;
 }
 //trigger:
 struct TriggerParams {
     bytes32 triggerId;
-    address plug;
+    bytes32 plug;
     bytes32 appGatewayId;
     uint32 chainSlug;
     bytes overrides;
@@ -146,7 +146,7 @@ struct UserCredits {
 
 // digest:
 struct DigestParams {
-    address socket;
+    bytes32 socket;
     address transmitter;
     bytes32 payloadId;
     uint256 deadline;
@@ -154,7 +154,7 @@ struct DigestParams {
     uint256 gasLimit;
     uint256 value;
     bytes payload;
-    address target;
+    bytes32 target;
     bytes32 appGatewayId;
     bytes32 prevDigestsHash;
 }
@@ -166,8 +166,8 @@ struct QueuePayloadParams {
     IsPlug isPlug;
     WriteFinality writeFinality;
     address asyncPromise;
-    address switchboard;
-    address target;
+    bytes32 switchboard;
+    bytes32 target;
     address appGateway;
     uint256 gasLimit;
     uint256 value;
@@ -183,8 +183,8 @@ struct PayloadSubmitParams {
     Parallel isParallel;
     WriteFinality writeFinality;
     address asyncPromise;
-    address switchboard;
-    address target;
+    bytes32 switchboard;
+    bytes32 target;
     address appGateway;
     uint256 gasLimit;
     uint256 value;
@@ -204,8 +204,8 @@ struct PayloadParams {
     // Parallel isParallel;
     // WriteFinality writeFinality;
     address asyncPromise;
-    address switchboard;
-    address target;
+    bytes32 switchboard;
+    bytes32 target;
     address appGateway;
     bytes32 payloadId;
     bytes32 prevDigestsHash;
@@ -244,6 +244,7 @@ struct RequestMetadata {
     bytes onCompleteData;
 }
 
+// TODO:GW: remove comment after review: ExecuteParams is for EVM calls - should we name it ExecuteParamsEvm?
 struct ExecuteParams {
     CallType callType;
     uint40 requestCount;
@@ -271,4 +272,25 @@ struct PayloadIdParams {
     uint40 payloadCount;
     uint32 chainSlug;
     address switchboard;
+}
+
+struct SolanaInstruction {
+    SolanaInstructionData data;
+    SolanaInstructionDataDescription description;
+}
+
+struct SolanaInstructionData {
+    bytes32 programId;
+    bytes8 instructionDiscriminator;
+    bytes32[] accounts;
+    bytes[] functionArguments;
+}
+
+struct SolanaInstructionDataDescription {
+    // flags for accounts
+    // 0 bit - isWritable (0|1)
+    // 1 bit - isSigner (0|1)
+    bytes1[] accountFlags;
+    // names for function argument types used later in data decoding in watcher and transmitter
+    string[] functionArgumentTypeNames;
 }

--- a/script/counter/ReadOnchainCounters.s.sol
+++ b/script/counter/ReadOnchainCounters.s.sol
@@ -5,21 +5,22 @@ import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 import {Counter} from "../../test/apps/app-gateways/counter/Counter.sol";
 import {CounterAppGateway} from "../../test/apps/app-gateways/counter/CounterAppGateway.sol";
+import {fromBytes32Format} from "../../contracts/utils/common/Converters.sol";
 
 contract CheckCounters is Script {
     function run() external {
         CounterAppGateway gateway = CounterAppGateway(vm.envAddress("APP_GATEWAY"));
 
         vm.createSelectFork(vm.envString("EVMX_RPC"));
-        address counterInstanceArbitrumSepolia = gateway.getOnChainAddress(
-            gateway.counter(),
-            421614
+        address counterInstanceArbitrumSepolia = fromBytes32Format(
+            gateway.getOnChainAddress(gateway.counter(), 421614)
         );
-        address counterInstanceOptimismSepolia = gateway.getOnChainAddress(
-            gateway.counter(),
-            11155420
+        address counterInstanceOptimismSepolia = fromBytes32Format(
+            gateway.getOnChainAddress(gateway.counter(), 11155420)
         );
-        address counterInstanceBaseSepolia = gateway.getOnChainAddress(gateway.counter(), 84532);
+        address counterInstanceBaseSepolia = fromBytes32Format(
+            gateway.getOnChainAddress(gateway.counter(), 84532)
+        );
 
         if (counterInstanceArbitrumSepolia != address(0)) {
             vm.createSelectFork(vm.envString("ARBITRUM_SEPOLIA_RPC"));

--- a/test/DeliveryHelper.t.sol
+++ b/test/DeliveryHelper.t.sol
@@ -153,28 +153,28 @@ contract DeliveryHelperTest is SetupTest {
 
         AppGatewayConfig[] memory gateways = new AppGatewayConfig[](4);
         gateways[0] = AppGatewayConfig({
-            plug: address(arbConfig.contractFactoryPlug),
+            plug: toBytes32Format(address(arbConfig.contractFactoryPlug)),
             chainSlug: arbChainSlug,
             appGatewayId: _encodeAppGatewayId(address(deliveryHelper)),
-            switchboard: address(arbConfig.switchboard)
+            switchboard: toBytes32Format(address(arbConfig.switchboard))
         });
         gateways[1] = AppGatewayConfig({
-            plug: address(optConfig.contractFactoryPlug),
+            plug: toBytes32Format(address(optConfig.contractFactoryPlug)),
             chainSlug: optChainSlug,
             appGatewayId: _encodeAppGatewayId(address(deliveryHelper)),
-            switchboard: address(optConfig.switchboard)
+            switchboard: toBytes32Format(address(optConfig.switchboard))
         });
         gateways[2] = AppGatewayConfig({
-            plug: address(arbConfig.feesPlug),
+            plug: toBytes32Format(address(arbConfig.feesPlug)),
             chainSlug: arbChainSlug,
             appGatewayId: _encodeAppGatewayId(address(feesManager)),
-            switchboard: address(arbConfig.switchboard)
+            switchboard: toBytes32Format(address(arbConfig.switchboard))
         });
         gateways[3] = AppGatewayConfig({
-            plug: address(optConfig.feesPlug),
+            plug: toBytes32Format(address(optConfig.feesPlug)),
             chainSlug: optChainSlug,
             appGatewayId: _encodeAppGatewayId(address(feesManager)),
-            switchboard: address(optConfig.switchboard)
+            switchboard: toBytes32Format(address(optConfig.switchboard))
         });
 
         bytes memory watcherSignature = _createWatcherSignature(
@@ -285,13 +285,13 @@ contract DeliveryHelperTest is SetupTest {
 
         SocketContracts memory socketConfig = getSocketConfig(chainSlug_);
         for (uint i = 0; i < contractIds_.length; i++) {
-            address plug = appGateway_.getOnChainAddress(contractIds_[i], chainSlug_);
+            bytes32 plug = appGateway_.getOnChainAddress(contractIds_[i], chainSlug_);
 
             gateways[i] = AppGatewayConfig({
                 plug: plug,
                 chainSlug: chainSlug_,
                 appGatewayId: _encodeAppGatewayId(address(appGateway_)),
-                switchboard: address(socketConfig.switchboard)
+                switchboard: toBytes32Format(address(socketConfig.switchboard))
             });
         }
 
@@ -359,10 +359,10 @@ contract DeliveryHelperTest is SetupTest {
         uint32 chainSlug_,
         bytes32 contractId_,
         IAppGateway appGateway_
-    ) internal view returns (address, address) {
-        address app = appGateway_.getOnChainAddress(contractId_, chainSlug_);
+    ) internal view returns (bytes32, address) {
+        bytes32 plug = appGateway_.getOnChainAddress(contractId_, chainSlug_);
         address forwarder = appGateway_.forwarderAddresses(contractId_, chainSlug_);
-        return (app, forwarder);
+        return (plug, forwarder);
     }
 
     function getContractFactoryPlug(uint32 chainSlug_) internal view returns (address) {

--- a/test/Inbox.t.sol
+++ b/test/Inbox.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.21;
 import {CounterAppGateway} from "./apps/app-gateways/counter/CounterAppGateway.sol";
 import {Counter} from "./apps/app-gateways/counter/Counter.sol";
 import "./DeliveryHelper.t.sol";
+import {toBytes32Format} from "../contracts/utils/common/Converters.sol";
 
 contract TriggerTest is DeliveryHelperTest {
     uint256 constant feesAmount = 0.01 ether;
@@ -40,10 +41,10 @@ contract TriggerTest is DeliveryHelperTest {
         // Setup gateway config for the watcher
         AppGatewayConfig[] memory gateways = new AppGatewayConfig[](1);
         gateways[0] = AppGatewayConfig({
-            plug: address(counter),
+            plug: toBytes32Format(address(counter)),
             chainSlug: arbChainSlug,
             appGatewayId: _encodeAppGatewayId(address(gateway)),
-            switchboard: address(arbConfig.switchboard)
+            switchboard: toBytes32Format(address(arbConfig.switchboard))
         });
 
         bytes memory watcherSignature = _createWatcherSignature(
@@ -54,7 +55,7 @@ contract TriggerTest is DeliveryHelperTest {
         watcherPrecompileConfig.setAppGateways(gateways, signatureNonce++, watcherSignature);
 
         hoax(watcherEOA);
-        watcherPrecompileConfig.setIsValidPlug(arbChainSlug, address(counter), true);
+        watcherPrecompileConfig.setIsValidPlug(arbChainSlug, toBytes32Format(address(counter)), true);
     }
 
     function testIncrementAfterTrigger() public {
@@ -92,7 +93,7 @@ contract TriggerTest is DeliveryHelperTest {
             triggerId: triggerId,
             chainSlug: arbChainSlug,
             appGatewayId: _encodeAppGatewayId(address(gateway)),
-            plug: address(counter),
+            plug: toBytes32Format(address(counter)),
             payload: payload,
             overrides: bytes("")
         });

--- a/test/SetupTest.t.sol
+++ b/test/SetupTest.t.sol
@@ -106,8 +106,8 @@ contract SetupTest is Test {
         watcherPrecompileConfig.setOnChainContracts(
             chainSlug_,
             toBytes32Format(address(socket)),
-            address(contractFactoryPlug),
-            address(feesPlug)
+            toBytes32Format(address(contractFactoryPlug)),
+            toBytes32Format(address(feesPlug))
         );
         SocketFeeManager socketFeeManager = new SocketFeeManager(owner, socketFees);
         hoax(watcherEOA);
@@ -286,7 +286,7 @@ contract SetupTest is Test {
         return
             socketBatcher.attestAndExecute(
                 params,
-                // TODO:GW:remove comment after review: SocketBatcher is only used in EVM so we convert to address
+                // SocketBatcher is only used in EVM so we convert to address
                 fromBytes32Format(payloadParams.switchboard),
                 digest,
                 watcherProof,
@@ -367,7 +367,6 @@ contract SetupTest is Test {
         );
         transmitterSig = _createSignature(transmitterDigest, transmitterPrivateKey);
 
-        // TODO:GW:remove comment after review: ExecuteParams is for EVM calls only so we use address types not bytes32
         params = ExecuteParams({
             callType: payloadParams.payloadHeader.getCallType(),
             deadline: payloadParams.deadline,

--- a/test/apps/Counter.t.sol
+++ b/test/apps/Counter.t.sol
@@ -122,7 +122,7 @@ contract CounterTest is DeliveryHelperTest {
     function testCounterReadMultipleChains() external {
         testCounterIncrementMultipleChains();
 
-        (bytes32 arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
+        (, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId,
             counterGateway

--- a/test/apps/Counter.t.sol
+++ b/test/apps/Counter.t.sol
@@ -38,7 +38,7 @@ contract CounterTest is DeliveryHelperTest {
         deploySetup();
         deployCounterApp(arbChainSlug);
 
-        (address onChain, address forwarder) = getOnChainAndForwarderAddresses(
+        (bytes32 onChain, address forwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId,
             counterGateway
@@ -67,20 +67,21 @@ contract CounterTest is DeliveryHelperTest {
         deploySetup();
         deployCounterApp(arbChainSlug);
 
-        (address arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
+        (bytes32 arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId,
             counterGateway
         );
+        address arbCounterAddress = fromBytes32Format(arbCounter);
 
-        uint256 arbCounterBefore = Counter(arbCounter).counter();
+        uint256 arbCounterBefore = Counter(arbCounterAddress).counter();
 
         address[] memory instances = new address[](1);
         instances[0] = arbCounterForwarder;
         counterGateway.incrementCounters(instances);
         executeRequest(new bytes[](0));
 
-        assertEq(Counter(arbCounter).counter(), arbCounterBefore + 1);
+        assertEq(Counter(arbCounterAddress).counter(), arbCounterBefore + 1);
     }
 
     function testCounterIncrementMultipleChains() public {
@@ -88,19 +89,21 @@ contract CounterTest is DeliveryHelperTest {
         deployCounterApp(arbChainSlug);
         deployCounterApp(optChainSlug);
 
-        (address arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
+        (bytes32 arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId,
             counterGateway
         );
-        (address optCounter, address optCounterForwarder) = getOnChainAndForwarderAddresses(
+        address arbCounterAddress = fromBytes32Format(arbCounter);
+        (bytes32 optCounter, address optCounterForwarder) = getOnChainAndForwarderAddresses(
             optChainSlug,
             counterId,
             counterGateway
         );
+        address optCounterAddress = fromBytes32Format(optCounter);
 
-        uint256 arbCounterBefore = Counter(arbCounter).counter();
-        uint256 optCounterBefore = Counter(optCounter).counter();
+        uint256 arbCounterBefore = Counter(arbCounterAddress).counter();
+        uint256 optCounterBefore = Counter(optCounterAddress).counter();
 
         address[] memory instances = new address[](2);
         instances[0] = arbCounterForwarder;
@@ -112,14 +115,14 @@ contract CounterTest is DeliveryHelperTest {
         chains[1] = optChainSlug;
 
         executeRequest(new bytes[](0));
-        assertEq(Counter(arbCounter).counter(), arbCounterBefore + 1);
-        assertEq(Counter(optCounter).counter(), optCounterBefore + 1);
+        assertEq(Counter(arbCounterAddress).counter(), arbCounterBefore + 1);
+        assertEq(Counter(optCounterAddress).counter(), optCounterBefore + 1);
     }
 
     function testCounterReadMultipleChains() external {
         testCounterIncrementMultipleChains();
 
-        (, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
+        (bytes32 arbCounter, address arbCounterForwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId,
             counterGateway

--- a/test/apps/ParallelCounter.t.sol
+++ b/test/apps/ParallelCounter.t.sol
@@ -43,23 +43,23 @@ contract ParallelCounterTest is DeliveryHelperTest {
         chainSlugs[1] = optChainSlug;
         deployCounterApps(chainSlugs);
 
-        (address onChainArb1, address forwarderArb1) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainArb1, address forwarderArb1) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId1,
             parallelCounterGateway
         );
-        (address onChainArb2, address forwarderArb2) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainArb2, address forwarderArb2) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             counterId2,
             parallelCounterGateway
         );
 
-        (address onChainOpt1, address forwarderOpt1) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainOpt1, address forwarderOpt1) = getOnChainAndForwarderAddresses(
             optChainSlug,
             counterId1,
             parallelCounterGateway
         );
-        (address onChainOpt2, address forwarderOpt2) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainOpt2, address forwarderOpt2) = getOnChainAndForwarderAddresses(
             optChainSlug,
             counterId2,
             parallelCounterGateway

--- a/test/apps/SuperToken.t.sol
+++ b/test/apps/SuperToken.t.sol
@@ -101,14 +101,15 @@ contract SuperTokenTest is DeliveryHelperTest {
     function testContractDeployment() public {
         _deploy(arbChainSlug, IAppGateway(appContracts.superTokenApp), contractIds);
 
-        (address onChain, address forwarder) = getOnChainAndForwarderAddresses(
+        (bytes32 onChain, address forwarder) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             appContracts.superToken,
             IAppGateway(appContracts.superTokenApp)
         );
+        address onChainAddress = fromBytes32Format(onChain);
 
         assertEq(
-            SuperToken(onChain).name(),
+            SuperToken(onChainAddress).name(),
             "SUPER TOKEN",
             "OnChain SuperToken name should be SUPER TOKEN"
         );
@@ -122,7 +123,7 @@ contract SuperTokenTest is DeliveryHelperTest {
             onChain,
             "Forwarder SuperToken onChainAddress should be correct"
         );
-        assertEq(SuperToken(onChain).owner(), owner, "SuperToken owner should be correct");
+        assertEq(SuperToken(onChainAddress).owner(), owner, "SuperToken owner should be correct");
     }
 
     /**
@@ -145,20 +146,22 @@ contract SuperTokenTest is DeliveryHelperTest {
     function testTransfer() public {
         beforeTransfer();
 
-        (address onChainArb, address forwarderArb) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainArb, address forwarderArb) = getOnChainAndForwarderAddresses(
             arbChainSlug,
             appContracts.superToken,
             IAppGateway(appContracts.superTokenApp)
         );
+        address onChainArbAddress = fromBytes32Format(onChainArb);
 
-        (address onChainOpt, address forwarderOpt) = getOnChainAndForwarderAddresses(
+        (bytes32 onChainOpt, address forwarderOpt) = getOnChainAndForwarderAddresses(
             optChainSlug,
             appContracts.superToken,
             IAppGateway(appContracts.superTokenApp)
         );
+        address onChainOptAddress = fromBytes32Format(onChainOpt);
 
-        uint256 arbBalanceBefore = SuperToken(onChainArb).balanceOf(owner);
-        uint256 optBalanceBefore = SuperToken(onChainOpt).balanceOf(owner);
+        uint256 arbBalanceBefore = SuperToken(onChainArbAddress).balanceOf(owner);
+        uint256 optBalanceBefore = SuperToken(onChainOptAddress).balanceOf(owner);
 
         transferOrder = SuperTokenAppGateway.TransferOrder({
             srcToken: forwarderArb,
@@ -173,12 +176,12 @@ contract SuperTokenTest is DeliveryHelperTest {
         executeRequest(new bytes[](0));
 
         assertEq(
-            SuperToken(onChainArb).balanceOf(owner),
+            SuperToken(onChainArbAddress).balanceOf(owner),
             arbBalanceBefore - srcAmount,
             "Arb balance should be decreased by srcAmount"
         );
         assertEq(
-            SuperToken(onChainOpt).balanceOf(owner),
+            SuperToken(onChainOptAddress).balanceOf(owner),
             optBalanceBefore + srcAmount,
             "Opt balance should be increased by srcAmount"
         );

--- a/test/apps/app-gateways/counter/CounterAppGateway.sol
+++ b/test/apps/app-gateways/counter/CounterAppGateway.sol
@@ -6,6 +6,7 @@ import "../../../../contracts/evmx/interfaces/IForwarder.sol";
 import "../../../../contracts/evmx/interfaces/IPromise.sol";
 import "./Counter.sol";
 import "./ICounter.sol";
+import {toBytes32Format} from "../../../../contracts/utils/common/Converters.sol";
 
 contract CounterAppGateway is AppGatewayBase, Ownable {
     bytes32 public counter = _createContractId("counter");
@@ -99,7 +100,7 @@ contract CounterAppGateway is AppGatewayBase, Ownable {
 
     // trigger from a chain
     function setIsValidPlug(uint32 chainSlug_, address plug_) public {
-        watcherPrecompileConfig().setIsValidPlug(chainSlug_, plug_, true);
+        watcherPrecompileConfig().setIsValidPlug(chainSlug_, toBytes32Format(plug_), true);
     }
 
     function increase(uint256 value_) external onlyWatcherPrecompile {

--- a/test/mock/MockWatcherPrecompile.sol
+++ b/test/mock/MockWatcherPrecompile.sol
@@ -5,7 +5,7 @@ import "../../contracts/evmx/interfaces/IAppGateway.sol";
 import "../../contracts/evmx/interfaces/IWatcherPrecompile.sol";
 import "../../contracts/evmx/interfaces/IPromise.sol";
 
-import {TimeoutRequest, TriggerParams, PlugConfig, ResolvedPromises, AppGatewayConfig} from "../../contracts/utils/common/Structs.sol";
+import {TimeoutRequest, TriggerParams, PlugConfigGeneric, ResolvedPromises, AppGatewayConfig} from "../../contracts/utils/common/Structs.sol";
 import {QUERY, FINALIZE, SCHEDULE} from "../../contracts/utils/common/Constants.sol";
 import {TimeoutDelayTooLarge, TimeoutAlreadyResolved, ResolvingTimeoutTooEarly, CallFailed, AppGatewayAlreadyCalled} from "../../contracts/utils/common/Errors.sol";
 import "solady/utils/ERC1967Factory.sol";
@@ -21,7 +21,7 @@ contract MockWatcherPrecompile {
     /// @dev timeoutId => TimeoutRequest struct
     mapping(bytes32 => TimeoutRequest) public timeoutRequests;
 
-    mapping(uint32 => mapping(bytes32 => PlugConfig)) internal _plugConfigs;
+    mapping(uint32 => mapping(bytes32 => PlugConfigGeneric)) internal _plugConfigs;
 
     /// @notice Error thrown when an invalid chain slug is provided
     error InvalidChainSlug();

--- a/test/mock/MockWatcherPrecompile.sol
+++ b/test/mock/MockWatcherPrecompile.sol
@@ -9,6 +9,7 @@ import {TimeoutRequest, TriggerParams, PlugConfig, ResolvedPromises, AppGatewayC
 import {QUERY, FINALIZE, SCHEDULE} from "../../contracts/utils/common/Constants.sol";
 import {TimeoutDelayTooLarge, TimeoutAlreadyResolved, ResolvingTimeoutTooEarly, CallFailed, AppGatewayAlreadyCalled} from "../../contracts/utils/common/Errors.sol";
 import "solady/utils/ERC1967Factory.sol";
+import {fromBytes32Format} from "../../contracts/utils/common/Converters.sol";
 
 /// @title WatcherPrecompile
 /// @notice Contract that handles payload verification, execution and app configurations
@@ -20,7 +21,7 @@ contract MockWatcherPrecompile {
     /// @dev timeoutId => TimeoutRequest struct
     mapping(bytes32 => TimeoutRequest) public timeoutRequests;
 
-    mapping(uint32 => mapping(address => PlugConfig)) internal _plugConfigs;
+    mapping(uint32 => mapping(bytes32 => PlugConfig)) internal _plugConfigs;
 
     /// @notice Error thrown when an invalid chain slug is provided
     error InvalidChainSlug();
@@ -159,17 +160,18 @@ contract MockWatcherPrecompile {
     /// @dev Reverts if chainSlug is 0
     function encodePayloadId(
         uint32 chainSlug_,
-        address plug_,
+        bytes32 plug_,
         uint256 counter_
     ) internal view returns (bytes32) {
         if (chainSlug_ == 0) revert InvalidChainSlug();
-        (, address switchboard) = getPlugConfigs(chainSlug_, plug_);
+        (, bytes32 switchboard) = getPlugConfigs(chainSlug_, plug_);
         // Encode payload ID by bit-shifting and combining:
         // chainSlug (32 bits) | switchboard address (160 bits) | counter (64 bits)
 
+        address switchboardAsAddress = fromBytes32Format(switchboard);
         return
             bytes32(
-                (uint256(chainSlug_) << 224) | (uint256(uint160(switchboard)) << 64) | counter_
+                (uint256(chainSlug_) << 224) | (uint256(uint160(switchboardAsAddress)) << 64) | counter_
             );
     }
 
@@ -185,8 +187,8 @@ contract MockWatcherPrecompile {
     /// @dev Returns zero addresses if configuration doesn't exist
     function getPlugConfigs(
         uint32 chainSlug_,
-        address plug_
-    ) public view returns (bytes32, address) {
+        bytes32 plug_
+    ) public view returns (bytes32, bytes32) {
         return (
             _plugConfigs[chainSlug_][plug_].appGatewayId,
             _plugConfigs[chainSlug_][plug_].switchboard


### PR DESCRIPTION
1. Change is applied all places that can touch multiple chains(non EVM also)

2. Cr fixes:
* feesPlug - address -> bytes32
* contractFactiory -> address -> bytes32
* PluginConf -> separate structs for on-chain evm protocol and for evmx (WatcherPlugin etc)